### PR TITLE
Revert "Creacion de metodo resta, y crearCoseno en Operadores.java"

### DIFF
--- a/SofMat.iml
+++ b/SofMat.iml
@@ -3,7 +3,7 @@
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
     <content url="file://$MODULE_DIR$">
-      <sourceFolder url="file://$MODULE_DIR$/main/java" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/src/main/java" isTestSource="false" />
     </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/src/main/java/softmath/Operadores.java
+++ b/src/main/java/softmath/Operadores.java
@@ -8,13 +8,4 @@ public class Operadores {
         return Math.pow(base,exponente);
     }
 
-
-    public static double resta(double nro1, double nro2) {
-        return (nro1 - nro2);
-    }
-
-    public static double crearCoseno(double angulo){
-        return Math.cos(Math.toRadians(angulo));
-
-    }
 }


### PR DESCRIPTION
Reverts Criss091292/SofMat#6
se revierte porque los nombres de los metodos no son los acordados.
los nombres de los metodos a integrar deben quedar asi: Resta(), Coseno()